### PR TITLE
[Minor][FAB-000] Puppet version bump en1-bde-qa03-1.1.1.7

### DIFF
--- a/values/bde/en1/qa03.yaml
+++ b/values/bde/en1/qa03.yaml
@@ -1,2 +1,2 @@
-puppetVersionEnvOverride: 
-  "002-00": 4.3133.0.8616
+puppetVersionEnvOverride:
+  "002-00": 1.1.1.7

--- a/values/bde/qa03.yaml
+++ b/values/bde/qa03.yaml
@@ -1,3 +1,3 @@
-puppetVersionEnvOverride: 
-  "002-00": 4.3133.0.8616
-  "002-01": 4.3133.0.8616
+puppetVersionEnvOverride:
+  "002-00": 1.1.1.7
+  "002-01": 1.1.1.7

--- a/values/proxy.yaml
+++ b/values/proxy.yaml
@@ -1,1 +1,1 @@
-puppetVersion: 4.3153.0.8640
+puppetVersion: 1.1.1.7


### PR DESCRIPTION
This PR bumps the Puppet version to '1.1.1.7' for environment 'en1bdeqa03'